### PR TITLE
Change libteec path according to gcc5

### DIFF
--- a/rootfs/initramfs-add-files.txt
+++ b/rootfs/initramfs-add-files.txt
@@ -14,10 +14,9 @@ slink /etc/rc.d/S09_optee /etc/init.d/optee 755 0 0
 
 # OP-TEE client
 file /bin/tee-supplicant ${TOP}/optee_client/out/export/bin/tee-supplicant 755 0 0
-dir /lib/${MULTIARCH} 755 0 0
-file /lib/${MULTIARCH}/libteec.so.1.0 ${TOP}/optee_client/out/export/lib/libteec.so.1.0 755 0 0
-slink /lib/${MULTIARCH}/libteec.so.1 libteec.so.1.0 755 0 0
-slink /lib/${MULTIARCH}/libteec.so libteec.so.1 755 0 0
+file /lib/libteec.so.1.0 ${TOP}/optee_client/out/export/lib/libteec.so.1.0 755 0 0
+slink /lib/libteec.so.1 libteec.so.1.0 755 0 0
+slink /lib/libteec.so libteec.so.1 755 0 0
 
 # OP-TEE tests
 dir /lib/optee_armtz 755 0 0


### PR DESCRIPTION
Necessary to work with GCC5.x changes in https://github.com/OP-TEE/build/pull/65 and https://github.com/OP-TEE/optee_os/pull/802

Signed-off-by: Joakim Bech joakim.bech@linaro.org
