### PR TITLE
grub.configfile: Remove unnecessary fs_label

### DIFF
--- a/grub/grub.configfile
+++ b/grub/grub.configfile
@@ -1,3 +1,2 @@
-search.fs_label boot root
-set prefix=($root)'/EFI/BOOT'
+set prefix='/EFI/BOOT'
 configfile $prefix/grub.cfg


### PR DESCRIPTION
Fixes minor error below, shown just before grub menu is launched:

error: no such device: boot.

Signed-off-by: Victor Chong <victor.chong@linaro.org>